### PR TITLE
Standardized the implementations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@
 
 This ia a library containing UUID generation and validation used in UPP's Golang services.
 
-There are 3 categories of operations offered (check examples at the bottom):
-- deriving an UUID from another UUID (and reverting): in deriveUUID.go
-- generating an UUID from a random string: in generateUUID.go
-- validating an UUID: in uuidValidation.go
+#### What methods should you use?
 
-Note: this library also contains methods that replicate java.util.UUID class (in uuid.go), which also offers a method to generate UUID (i.e. NewNameUUIDFromBytes) that uses the old V3 UUID implementation, instead of V5, so it is advised not to use it if possible (use the method NewV5UUIDFrom).
+1. Generating an UUID based on another UUID: methods in deriveUUID.go
+
+2. Generating an UUID from an random string (V3 version, i.e. using MD5 hashing): methods in generateV3UUID.go
+
+3. Generating an UUID from an URL (V5 version, i.e. using SHA1 hashing): methods in generateV5UUID.go
+
+4. Validating an UUID: methods in uuidValidation.go
+
+Note: this library also contains methods that replicate java.util.UUID class (in uuid.go), for cases where it's already in use.
 
 ## Installation:
 
@@ -30,7 +35,7 @@ Note2: change in the fetch example above the appropriate tag release you want: @
 
 ## Usage examples:
 
-1. Deriving an UUID from another UUID (and reverting):
+1. Generating an UUID based on another UUID:
 
             originalUUID, _ := uuidutils.NewUUIDFromString("0000ea79-00a5-504e-a28d-11bd108b35ac")
             uuidDeriver := uuidutils.NewUUIDDeriverWith(uuidutils.IMAGE_SET)
@@ -39,12 +44,17 @@ Note2: change in the fetch example above the appropriate tag release you want: @
             
             revertToOriginalUUID := uuidDeriver.From(derivedUUID)
             
-2. Generate an UUID from a random string:
+2. Generating an UUID from an random string (V3 version, i.e. using MD5 hashing):
 
             someString := "1AB23ad1x34"
-            generatedUUID := uuidutils.NewV5UUIDFrom(someString)
+            generatedUUID := uuidutils.NewV3UUID(someString)
 
-3. Validate an UUID:
+3. Generating an UUID from an URL (V5 version, i.e. using SHA1 hashing):
+
+            someString := "1AB23ad1x34"
+            generatedUUID := uuidutils.NewDoubleDigestedV3UUID(someString)
+
+4. Validating an UUID:
 
             someUUID := "0000ea79-00a5-504e-a28d-11bd108b35ac"
             err := ValidateUUID(validUUID)

--- a/deriveUUID.go
+++ b/deriveUUID.go
@@ -37,7 +37,7 @@ func otherUUID(otherUUID *UUID, saltUUIDLsb *bitset.BitSet) (*UUID, error) {
 }
 
 func saltToUUIDLsb(salt Salt) *bitset.BitSet {
-	return toBitSet(NewNameUUIDFromBytes([]byte(string(salt))).lsb)
+	return toBitSet(newNameUUIDFromBytes([]byte(string(salt))).lsb)
 }
 
 func toBitSet(number uint64) *bitset.BitSet {

--- a/generateV3UUID.go
+++ b/generateV3UUID.go
@@ -1,0 +1,18 @@
+package uuidutils
+
+import (
+	"crypto/md5"
+)
+
+// NewV3UUID generates a new V3 UUID based on a random string
+// Corresponds to com.ft.uuidutils.GenerateV3UUID#singleDigested(String data)
+func NewV3UUID(data string) *UUID {
+	return NewNameUUIDFromBytes([]byte(data))
+}
+
+// NewDoubleDigestedV3UUID generates a new V3 UUID based on a random string
+// Corresponds to com.ft.uuidutils.GenerateV3UUID#doubleDigested(String data)
+func NewDoubleDigestedV3UUID(data string) *UUID {
+	firstDigest := md5.Sum([]byte(data))
+	return NewNameUUIDFromBytes(firstDigest[:])
+}

--- a/generateV3UUID.go
+++ b/generateV3UUID.go
@@ -7,12 +7,12 @@ import (
 // NewV3UUID generates a new V3 UUID based on a random string
 // Corresponds to com.ft.uuidutils.GenerateV3UUID#singleDigested(String data)
 func NewV3UUID(data string) *UUID {
-	return NewNameUUIDFromBytes([]byte(data))
+	return newNameUUIDFromBytes([]byte(data))
 }
 
 // NewDoubleDigestedV3UUID generates a new V3 UUID based on a random string
 // Corresponds to com.ft.uuidutils.GenerateV3UUID#doubleDigested(String data)
 func NewDoubleDigestedV3UUID(data string) *UUID {
 	firstDigest := md5.Sum([]byte(data))
-	return NewNameUUIDFromBytes(firstDigest[:])
+	return newNameUUIDFromBytes(firstDigest[:])
 }

--- a/generateV3UUID_test.go
+++ b/generateV3UUID_test.go
@@ -1,0 +1,36 @@
+package uuidutils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_NewSingleDigestedV3UUID_IsSuccessful(t *testing.T) {
+	resultUUID := NewV3UUID("some random text")
+
+	assert.Equal(t, "07671a03-8c0e-3437-a3d4-21693b073c3b", resultUUID.String())
+}
+
+func Test_NewSingleDigestedV3UUID_IsRepeatable(t *testing.T) {
+	randomText := "some random text"
+
+	firstGeneratedUUID := NewV3UUID(randomText)
+	secondGeneratedUUID := NewV3UUID(randomText)
+
+	assert.Equal(t, firstGeneratedUUID.String(), secondGeneratedUUID.String(), "Derived original UUID didn't matched same derived UUID.")
+}
+
+func Test_NewDoubleDigestedV3UUID_IsSuccessful(t *testing.T) {
+	resultUUID := NewDoubleDigestedV3UUID("some random text")
+
+	assert.Equal(t, "5cdd4e45-5f40-3e8f-a75a-29e051ae6b37", resultUUID.String())
+}
+
+func Test_NewDoubleDigestedV3UUID_IsRepeatable(t *testing.T) {
+	randomText := "some random text"
+
+	firstGeneratedUUID := NewDoubleDigestedV3UUID(randomText)
+	secondGeneratedUUID := NewDoubleDigestedV3UUID(randomText)
+
+	assert.Equal(t, firstGeneratedUUID.String(), secondGeneratedUUID.String(), "Derived original UUID didn't matched same derived UUID.")
+}

--- a/generateV5UUID.go
+++ b/generateV5UUID.go
@@ -3,21 +3,22 @@ package uuidutils
 import (
 	"crypto/sha1"
 	"encoding/binary"
+	"net/url"
 )
 
 const (
 	NAMESPACE_URL_ID = "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
 )
 
-// NewGenerateUUID gives a new V5 UUID based on a random string
-// Corresponds to com.ft.uuidutils.GenerateUuid#from(final String string)
-func NewV5UUIDFrom(str string) UUID {
-	digest := newV5Digest(NAMESPACE_URL_ID, str)
+// NewV5UUIDFromURL generates a new V5 UUID based on an URL
+// Corresponds to com.ft.uuidutils.GenerateV5UUID#fromURL(final URL url)
+func NewV5UUIDFromURL(url *url.URL) *UUID {
+	digest := newV5Digest(NAMESPACE_URL_ID, url.String())
 
 	hi := createMSB(digest)
 	lo := createLSB(digest)
 
-	return UUID{binary.BigEndian.Uint64(hi), binary.BigEndian.Uint64(lo)}
+	return &UUID{binary.BigEndian.Uint64(hi), binary.BigEndian.Uint64(lo)}
 }
 
 func newV5Digest(ns string, str string) []byte {

--- a/generateV5UUID_test.go
+++ b/generateV5UUID_test.go
@@ -3,14 +3,21 @@ package uuidutils
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"net/url"
 )
 
 func Test_NewV5UUIDFrom_IsSuccessful(t *testing.T) {
-	resultUUIDRadu := NewV5UUIDFrom("http://api.ft.com/duders/Radu")
-	resultUUIDBogdan := NewV5UUIDFrom("http://api.ft.com/duders/Bogdan")
-	resultUUIDHuni := NewV5UUIDFrom("http://api.ft.com/duders/Huni")
-	resultUUIDGeorge := NewV5UUIDFrom("http://api.ft.com/duders/George")
-	resultUUIDRandomID := NewV5UUIDFrom("http://api.ft.com/things/U11603507121721xBE")
+	urlRadu, _ := url.Parse("http://api.ft.com/duders/Radu")
+	urlBogdan, _ := url.Parse("http://api.ft.com/duders/Bogdan")
+	urlHuni, _ := url.Parse("http://api.ft.com/duders/Huni")
+	urlGeorge, _ := url.Parse("http://api.ft.com/duders/George")
+	urlRandomID, _ := url.Parse("http://api.ft.com/things/U11603507121721xBE")
+
+	resultUUIDRadu := NewV5UUIDFromURL(urlRadu)
+	resultUUIDBogdan := NewV5UUIDFromURL(urlBogdan)
+	resultUUIDHuni := NewV5UUIDFromURL(urlHuni)
+	resultUUIDGeorge := NewV5UUIDFromURL(urlGeorge)
+	resultUUIDRandomID := NewV5UUIDFromURL(urlRandomID)
 
 	assert.Equal(t, "0000ea79-00a5-504e-a28d-11bd108b35ac", resultUUIDRadu.String(), "Expected UUID didn't matched")
 	assert.Equal(t, "000025f3-00da-50bc-a6b1-271b74f9130f", resultUUIDBogdan.String(), "Expected UUID didn't matched")
@@ -19,11 +26,11 @@ func Test_NewV5UUIDFrom_IsSuccessful(t *testing.T) {
 	assert.Equal(t, "00006a43-00dd-5084-ba5e-1b05d24a06e0", resultUUIDRandomID.String(), "Expected UUID didn't matched")
 }
 
-func Test_NewV5UUIDFrom_IsRepeatable(t *testing.T) {
-	someString := "some string"
+func Test_NewV5UUIDFromURL_IsRepeatable(t *testing.T) {
+	urlBogdan, _ := url.Parse("http://api.ft.com/duders/Radu")
 
-	firstGeneratedUUID := NewV5UUIDFrom(someString)
-	secondGeneratedUUID := NewV5UUIDFrom(someString)
+	firstGeneratedUUID := NewV5UUIDFromURL(urlBogdan)
+	secondGeneratedUUID := NewV5UUIDFromURL(urlBogdan)
 
 	assert.Equal(t, firstGeneratedUUID.String(), secondGeneratedUUID.String(), "Derived original UUID didn't matched same derived UUID.")
 }

--- a/uuid.go
+++ b/uuid.go
@@ -14,29 +14,6 @@ type UUID struct {
 	lsb uint64
 }
 
-// NewNameUUIDFromBytes creates a type 3 - name based - UUID
-// based on the specified byte array.
-// Corresponds to java.util.UUID#nameUUIDFromBytes
-func NewNameUUIDFromBytes(bytes []byte) *UUID {
-	md5Hash := md5.Sum(bytes)
-	md5Hash[6] &= 0x0f /* clear version        */
-	md5Hash[6] |= 0x30 /* set to version 3     */
-	md5Hash[8] &= 0x3f /* clear variant        */
-	md5Hash[8] |= 0x80 /* set to IETF variant  */
-
-	var msb uint64
-	var lsb uint64
-
-	for i := 0; i < 8; i++ {
-		msb = (msb << 8) | (uint64(md5Hash[i]) & 0xff)
-	}
-	for i := 8; i < 16; i++ {
-		lsb = (lsb << 8) | (uint64(md5Hash[i]) & 0xff)
-	}
-
-	return &UUID{msb, lsb}
-}
-
 // NewUUIDFromString creates a UUID from the standard string representation
 // Corresponds to java.util.UUID#fromString
 func NewUUIDFromString(uuidString string) (*UUID, error) {
@@ -75,6 +52,30 @@ func (uuid *UUID) String() string {
 	parts[4] = digits(uuid.lsb, 12)
 
 	return strings.Join(parts, "-")
+}
+
+// NewNameUUIDFromBytes creates a type 3 - name based - UUID
+// based on the specified byte array.
+// Corresponds to java.util.UUID#nameUUIDFromBytes
+// NOTE: for consistency please use our wrapper method NewV3UUID (which just wraps this method)
+func newNameUUIDFromBytes(bytes []byte) *UUID {
+	md5Hash := md5.Sum(bytes)
+	md5Hash[6] &= 0x0f /* clear version        */
+	md5Hash[6] |= 0x30 /* set to version 3     */
+	md5Hash[8] &= 0x3f /* clear variant        */
+	md5Hash[8] |= 0x80 /* set to IETF variant  */
+
+	var msb uint64
+	var lsb uint64
+
+	for i := 0; i < 8; i++ {
+		msb = (msb << 8) | (uint64(md5Hash[i]) & 0xff)
+	}
+	for i := 8; i < 16; i++ {
+		lsb = (lsb << 8) | (uint64(md5Hash[i]) & 0xff)
+	}
+
+	return &UUID{msb, lsb}
 }
 
 // Corresponds to java.util.UUID#digits


### PR DESCRIPTION
This adds V3 UUID generation (code already used by semantic).
Note: this code is used in Java projects, but added here for parity/consistency reasons with the java lib (uuid-utils-java).

This changes method names based on the following agreed conventions:
- use V3 if you have a plain string, 
- use V5 if you have a url.

+use derive if you generate UUID based on another UUID (this remained unchanged).